### PR TITLE
fix for ISO date format and changes related to data requirment @ front

### DIFF
--- a/refset-query-interface/pom.xml
+++ b/refset-query-interface/pom.xml
@@ -15,7 +15,7 @@
 		<org.slf4j-version>1.6.6</org.slf4j-version>
 		<refset-query-interface-app-port>8081</refset-query-interface-app-port>
 		<camel-version>2.13.2</camel-version>
-		<jackson.version>1.9.13</jackson.version>
+		<com.fasterxml.jackson-version>2.4.0</com.fasterxml.jackson-version>
 		<powermock-version>1.5.5</powermock-version>
 	</properties>
 	<dependencies>
@@ -253,12 +253,30 @@
 		    <version>0.6.5</version>
 		</dependency>
 		
+		
 		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-core-asl</artifactId>
-			<version>${jackson.version}</version>
+  			<groupId>com.fasterxml.jackson.core</groupId>
+  			<artifactId>jackson-core</artifactId>
+		    <version>${com.fasterxml.jackson-version}</version>
 		</dependency>
-
+		
+		<dependency>
+   			<groupId>com.fasterxml.jackson.datatype</groupId>
+    		<artifactId>jackson-datatype-joda</artifactId>
+		    <version>${com.fasterxml.jackson-version}</version>
+		</dependency>
+		
+		<dependency>
+		  <!-- note: typically only ".0" patch version exists for core annotations -->
+		  <groupId>com.fasterxml.jackson.core</groupId>
+		  <artifactId>jackson-annotations</artifactId>
+		    <version>${com.fasterxml.jackson-version}</version>
+		</dependency>
+		<dependency>
+		    <groupId>com.fasterxml.jackson.core</groupId>
+		    <artifactId>jackson-databind</artifactId>
+		    <version>${com.fasterxml.jackson-version}</version>
+		</dependency>
 	    <dependency>
 	        <groupId>org.springframework.batch</groupId>
 	        <artifactId>spring-batch-core</artifactId>
@@ -266,9 +284,14 @@
 	    </dependency>
 	    
 		<dependency>
-			<groupId>net.sf.opencsv</groupId>
-			<artifactId>opencsv</artifactId>
-			<version>2.0</version>
+			<groupId>net.sf.supercsv</groupId>
+			<artifactId>super-csv</artifactId>
+			<version>2.2.0</version>
+		</dependency>
+		<dependency>
+			<groupId>net.sf.supercsv</groupId>
+			<artifactId>super-csv-dozer</artifactId>
+			<version>2.2.0</version>
 		</dependency>
 
 

--- a/refset-query-interface/src/main/java/org/ihtsdo/otf/refset/common/Meta.java
+++ b/refset-query-interface/src/main/java/org/ihtsdo/otf/refset/common/Meta.java
@@ -9,6 +9,22 @@ public class Meta extends ResourceSupport {
 	
 	private String message;
 	
+	private int noOfRecords;
+	
+
+	/**
+	 * @return the noOfRecords
+	 */
+	public int getNoOfRecords() {
+		return noOfRecords;
+	}
+
+	/**
+	 * @param noOfRecords the noOfRecords to set
+	 */
+	public void setNoOfRecords(int noOfRecords) {
+		this.noOfRecords = noOfRecords;
+	}
 
 	/**
 	 * @return the status

--- a/refset-query-interface/src/main/java/org/ihtsdo/otf/refset/controller/RefsetBrowseController.java
+++ b/refset-query-interface/src/main/java/org/ihtsdo/otf/refset/controller/RefsetBrowseController.java
@@ -55,6 +55,7 @@ public class RefsetBrowseController {
 		Response<Map<String, Object>> response = new Response<Map<String, Object>>();
 		Meta m = new Meta();
 		m.add( linkTo( methodOn( RefsetBrowseController.class ).getRefsets( page, size ) ).withSelfRel() );
+		
 		response.setMeta(m);
 
     	try {
@@ -63,7 +64,7 @@ public class RefsetBrowseController {
 
 			Map<String, Object> data = new HashMap<String, Object>();
 			data.put("refsets", refSets);
-			
+			m.setNoOfRecords(refSets.size());
 			response.setData(data);
 			
 			m.setMessage(SUCESS);

--- a/refset-query-interface/src/main/java/org/ihtsdo/otf/refset/domain/Refset.java
+++ b/refset-query-interface/src/main/java/org/ihtsdo/otf/refset/domain/Refset.java
@@ -7,12 +7,18 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.springframework.util.StringUtils;
+
 /**
  * @author Episteme Partners
  *
  */
 public class Refset {
-		
+	private static final DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyyMMdd");
+
 	
 	@NotNull
 	private String id;
@@ -45,6 +51,8 @@ public class Refset {
 	private String typeId;
 	
 	private String superRefsetTypeId;
+	
+
 
 	/**
 	 * @return the typeId
@@ -134,10 +142,16 @@ public class Refset {
 	 * @return the created
 	 */
 	public String getCreated() {
+
+		if( !StringUtils.isEmpty(created) ) {
+
+			DateTime dt = formatter.parseDateTime(created);
+			created = dt.toString();
+		}
+		
 		return created;
 	}
 
-	
 	public void setCreated(String date) {
 		
 		this.created = date;
@@ -204,6 +218,14 @@ public class Refset {
 	 * @return the publishedDate
 	 */
 	public String getPublishedDate() {
+		
+		if( !StringUtils.isEmpty(publishedDate) ) {
+			
+			DateTime dt = formatter.parseDateTime(publishedDate);
+
+			publishedDate = dt.toString();
+		}
+		
 		return publishedDate;
 	}
 
@@ -219,6 +241,13 @@ public class Refset {
 	 * @return the effectiveDate
 	 */
 	public String getEffectiveTime() {
+		//TODO NEED TO GET ISO TIME HENCE THIS WORKAROUND. Util date based conversion is gets 2013-01-12T00:00:00.+0000 which is not ISO as required at fronend
+		if( !StringUtils.isEmpty(effectiveTime) ) {
+			DateTime dt = formatter.parseDateTime(effectiveTime);
+
+			effectiveTime = dt.toString();
+		}
+		
 		return effectiveTime;
 	}
 
@@ -239,7 +268,9 @@ public class Refset {
 	   
 	   return ( this.id == r.id );
 	   
-   }	
+   }
+   
+   
    
    @Override
    public String toString() {

--- a/refset-query-interface/src/main/java/org/ihtsdo/otf/refset/service/RefsetBrowseServiceStub.java
+++ b/refset-query-interface/src/main/java/org/ihtsdo/otf/refset/service/RefsetBrowseServiceStub.java
@@ -31,8 +31,19 @@ public class RefsetBrowseServiceStub implements RefsetBrowseService {
 	public List<Refset> getRefsets(Integer page, Integer size) throws RefsetServiceException {
 
 		LOGGER.debug("getRefsets");
+		if( page == 1 && size == 10) { return dataService.getRefSets();}
 		
-		return dataService.getRefSets().subList(0, 10);
+		List<Refset> refsets = dataService.getRefSets();
+		
+		int total = refsets.size();
+		
+		int from_temp = page >= 1 ? (Math.min(total, Math.abs(page * size)) - size) : 0;
+		
+		int from = from_temp >= 0 ? from_temp : 0;
+		
+		int temp = Math.min(total, Math.abs(page * size));
+		int to = temp <= total ? temp : total;
+		return refsets.subList(from, to);
 		
 	}
 

--- a/refset-query-interface/src/main/java/org/ihtsdo/otf/refset/service/RefsetBrowseServiceStubData.java
+++ b/refset-query-interface/src/main/java/org/ihtsdo/otf/refset/service/RefsetBrowseServiceStubData.java
@@ -19,10 +19,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
-
-import au.com.bytecode.opencsv.CSVReader;
-import au.com.bytecode.opencsv.bean.ColumnPositionMappingStrategy;
-import au.com.bytecode.opencsv.bean.CsvToBean;
+import org.supercsv.cellprocessor.ParseBool;
+import org.supercsv.cellprocessor.ParseDate;
+import org.supercsv.cellprocessor.ParseLong;
+import org.supercsv.cellprocessor.constraint.NotNull;
+import org.supercsv.cellprocessor.constraint.UniqueHashCode;
+import org.supercsv.cellprocessor.ift.CellProcessor;
+import org.supercsv.io.dozer.CsvDozerBeanReader;
+import org.supercsv.io.dozer.ICsvDozerBeanReader;
+import org.supercsv.prefs.CsvPreference;
 
 /**
  * @author Episteme Partners
@@ -34,7 +39,10 @@ public class RefsetBrowseServiceStubData {
 	private static final String REFSET_LIST = "refset";
 	private static final String MEMBER_LIST = "members";
 	private static Map<String, Integer> refsetIdsAndMembers = new HashMap<String, Integer>() ;
-	
+	private static final String[] REFSET_MAPPING = new String[] {"id", "description", "created", "createdBy", "languageCode", 
+			"type", "publishedDate", "effectiveTime", "moduleId", "published"};
+	private static String[] MEMBER_MAPPING = new String[] {"referenceComponentId", "effectiveTime", "active", "moduleId"}; 
+
 	static 
 	{
 		/**
@@ -50,6 +58,55 @@ public class RefsetBrowseServiceStubData {
 			703870018
 			447566010
 			447565011
+			
+			700043023
+450973025
+450971027
+703870028
+447566020
+447565021
+700043033
+450973035
+450971037
+703870038
+447566030
+447565031
+700043043
+450973045
+450971047
+703870048
+447566040
+447565041
+700043053
+450973055
+450971057
+703870058
+447566050
+447565051
+700043063
+450973065
+450971067
+703870068
+447566060
+447565061
+700043073
+450973075
+450971077
+703870078
+447566070
+447565071
+700043083
+450973085
+450971087
+703870088
+447566080
+447565081
+700043093
+450973095
+450971097
+703870098
+447566090
+
 		 */
 		
 		
@@ -65,6 +122,63 @@ public class RefsetBrowseServiceStubData {
 		refsetIdsAndMembers.put("703870018", 3000);
 		refsetIdsAndMembers.put("447566010", 3300);
 		refsetIdsAndMembers.put("447565011", 3600);
+		
+		refsetIdsAndMembers.put("700043023", 300);
+		refsetIdsAndMembers.put("450973025", 600);
+		refsetIdsAndMembers.put("450971027", 900);
+		refsetIdsAndMembers.put("703870028", 1200);
+		refsetIdsAndMembers.put("447566020", 1500);
+		refsetIdsAndMembers.put("447565021", 18000);
+		
+		refsetIdsAndMembers.put("700043033", 2100);
+		refsetIdsAndMembers.put("450973035", 2400);
+		refsetIdsAndMembers.put("450971037", 2700);
+		refsetIdsAndMembers.put("703870038", 3000);
+		refsetIdsAndMembers.put("447566030", 3300);
+		refsetIdsAndMembers.put("447565031", 3600);
+
+		
+		refsetIdsAndMembers.put("700043043", 2100);
+		refsetIdsAndMembers.put("450973045", 2400);
+		refsetIdsAndMembers.put("450971047", 2700);
+		refsetIdsAndMembers.put("703870048", 3000);
+		refsetIdsAndMembers.put("447566040", 3300);
+		refsetIdsAndMembers.put("447565041", 3600);
+		
+		refsetIdsAndMembers.put("700043053", 2100);
+		refsetIdsAndMembers.put("450973055", 2400);
+		refsetIdsAndMembers.put("450971057", 2700);
+		refsetIdsAndMembers.put("703870058", 3000);
+		refsetIdsAndMembers.put("447566050", 3300);
+		refsetIdsAndMembers.put("447565051", 3600);
+		
+		refsetIdsAndMembers.put("700043063", 2100);
+		refsetIdsAndMembers.put("450973065", 2400);
+		refsetIdsAndMembers.put("450971067", 2700);
+		refsetIdsAndMembers.put("703870068", 3000);
+		refsetIdsAndMembers.put("447566060", 3300);
+		refsetIdsAndMembers.put("447565061", 3600);
+		
+		refsetIdsAndMembers.put("700043073", 2100);
+		refsetIdsAndMembers.put("450973075", 2400);
+		refsetIdsAndMembers.put("450971077", 2700);
+		refsetIdsAndMembers.put("703870078", 3000);
+		refsetIdsAndMembers.put("447566070", 3300);
+		refsetIdsAndMembers.put("447565071", 3600);
+		
+		refsetIdsAndMembers.put("700043083", 2100);
+		refsetIdsAndMembers.put("450973085", 2400);
+		refsetIdsAndMembers.put("450971087", 2700);
+		refsetIdsAndMembers.put("703870088", 3000);
+		refsetIdsAndMembers.put("447566080", 3300);
+		refsetIdsAndMembers.put("447565081", 3600);
+		
+		refsetIdsAndMembers.put("700043093", 2100);
+		refsetIdsAndMembers.put("450973095", 2400);
+		refsetIdsAndMembers.put("450971097", 2700);
+		refsetIdsAndMembers.put("703870098", 3000);
+		refsetIdsAndMembers.put("447566090", 3300);
+		refsetIdsAndMembers.put("447565091", 3600);
 
 	}
 
@@ -83,21 +197,20 @@ public class RefsetBrowseServiceStubData {
 		
 		List<Refset> refsets = new ArrayList<Refset>();
 		
-		ColumnPositionMappingStrategy<Refset> s = new ColumnPositionMappingStrategy<Refset>();
+		ICsvDozerBeanReader s = null;
 		
-		String[] columns = new String[] {"id", "description", "created", "createdBy", "languageCode", 
-				"type", "publishedDate", "effectiveTime", "moduleId", "published"}; 
-		s.setColumnMapping(columns);
-		s.setType(Refset.class);
-		
-		CsvToBean<Refset> refset = new CsvToBean<Refset>();		
-	    CSVReader reader = null;
-	    
 		try {
 			
-			reader = new CSVReader(new FileReader(csv.getFile()), ',');
-			List<Refset> list = refset.parse(s, reader);
-			refsets.addAll(list);
+			s = new CsvDozerBeanReader(new FileReader(csv.getFile()), CsvPreference.STANDARD_PREFERENCE);
+			 
+			s.getHeader(true); // ignore the header
+			s.configureBeanMapping(Refset.class, REFSET_MAPPING);
+			Refset r = null;
+			while( (r = s.read(Refset.class, getRefSetProcessors())) != null ) {
+	           
+				refsets.add(r);
+
+			}
 			
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
@@ -106,11 +219,11 @@ public class RefsetBrowseServiceStubData {
 			
 		} finally {
 			
-			if (reader != null) {
+			if (s != null) {
 				
 				try {
 					
-					reader.close();
+					s.close();
 					
 				} catch (IOException e) {
 					
@@ -160,27 +273,20 @@ public class RefsetBrowseServiceStubData {
 		
 		List<Member> members = new ArrayList<Member>();
 		
-		ColumnPositionMappingStrategy<Member> s = new ColumnPositionMappingStrategy<Member>();
+		ICsvDozerBeanReader s = null;
 		
-		String[] columns = new String[] {"referenceComponentId", "effectiveTime", "active", "moduleId"}; 
-		s.setColumnMapping(columns);
-		s.setType(Member.class);
-		
-		CsvToBean<Member> m = new CsvToBean<Member>();		
-	    CSVReader reader = null;
-	    
 		try {
 			
-			reader = new CSVReader(new FileReader(csv.getFile()), ',');
-			List<Member> list = m.parse(s, reader);
-			
-			for (Member member : list) {
-				
-				member.setId(UUID.randomUUID().toString());
-				members.add(member);
+			s = new CsvDozerBeanReader(new FileReader(csv.getFile()), CsvPreference.STANDARD_PREFERENCE);
+			 
+			s.getHeader(true); // ignore the header
+			s.configureBeanMapping(Member.class, MEMBER_MAPPING);
+			Member m = null;
+			while( (m = s.read(Member.class, getMemberProcessors())) != null ) {
+	            
+	            members.add(m);
+
 			}
-			
-			members.addAll(list);
 			
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
@@ -189,11 +295,11 @@ public class RefsetBrowseServiceStubData {
 			
 		} finally {
 			
-			if (reader != null) {
+			if (s != null) {
 				
 				try {
 					
-					reader.close();
+					s.close();
 					
 				} catch (IOException e) {
 					
@@ -208,6 +314,43 @@ public class RefsetBrowseServiceStubData {
 		List<Member> ms = members.subList(refsetIdsAndMembers.get(result.getId()) - 300, refsetIdsAndMembers.get(result.getId()));
 		result.setMembers(Collections.unmodifiableList(ms));
 		return result;
+	}
+	
+	
+	private static CellProcessor[] getRefSetProcessors() {
+		
+		/**String[] columns = new String[] {"id", "description", "created", "createdBy", "languageCode", 
+				"type", "publishedDate", "effectiveTime", "moduleId", "published"};*/
+		final CellProcessor[] processors = new CellProcessor[] { 
+				new UniqueHashCode(), // id
+				new NotNull(), // description
+				new NotNull(), // publishedDate
+				new NotNull(), // createdBy
+				new NotNull(), // languageCode
+				new NotNull(), // type
+				new NotNull(), // publishedDate
+				new NotNull(), // publishedDate
+				new NotNull(), // moduleId
+				new NotNull(new ParseBool()), // published
+				
+		};
+		
+		return processors;
+	}
+	
+	private static CellProcessor[] getMemberProcessors() {
+		
+		/**	private static String[] MEMBER_MAPPING = new String[] {"referenceComponentId", "effectiveTime", "active", "moduleId"}; */
+		final CellProcessor[] processors = new CellProcessor[] { 
+				
+				new UniqueHashCode(), // referenceComponentId
+				new NotNull(new ParseLong()), // effectiveTime
+				new NotNull(new ParseBool()), // active
+				new NotNull(), // moduleId
+
+		};
+		
+		return processors;
 	}
 
 	/**

--- a/refset-query-interface/src/main/resources/data/refset.csv
+++ b/refset-query-interface/src/main/resources/data/refset.csv
@@ -1,60 +1,60 @@
-700043003,Example problem list concepts reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-450973005,GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
+700043003,Example problem list concepts reference set (foundation metadata concept),201201120101,Refset Stub,en_US,simple,201201190101,201301190101,900000000000012004,true
+450973005,GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
 450971007,GP/FP reason for encounter reference set (foundation metadata concept),20130112,Refset Stub,en_US,simple,20130119,20130119,900000000000012004,true
 703870008,Laterality indicator reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-447566000,Virtual medicinal product simple reference set (foundation metadata concept),20140112,Refset Stub,en_US,simple,20140119,20130119,900000000000012004,true
+447566000,Virtual medicinal product simple reference set (foundation metadata concept),20140112,Refset Stub,en_US,simple,20140119,20130119,900000000000012004,false
 447565001,Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-700043013,Dummy -1 Example problem list concepts reference set (foundation metadata concept),20130112,Refset Stub,en_US,simple,20130119,20130119,900000000000012004,true
-450973015,Dummy -1 GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-450971017,Dummy -1 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
+700043013,Dummy -1 Example problem list concepts reference set (foundation metadata concept),20130112,Refset Stub,en_US,simple,20130119,20130119,900000000000012004,false
+450973015,Dummy -1 GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+450971017,Dummy -1 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
 703870018,Dummy -1 Laterality indicator reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
 447566010,Dummy -1 Virtual medicinal product simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-447565011,Dummy -1 Virtual therapeutic moiety simple reference set (foundation metadata concept),20130112,Refset Stub,en_US,simple,20130119,20130119,900000000000012004,true
+447565011,Dummy -1 Virtual therapeutic moiety simple reference set (foundation metadata concept),20130112,Refset Stub,en_US,simple,20130119,20130119,900000000000012004,false
 700043023,Dummy -2 Example problem list concepts reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
 450973025,Dummy -2 GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-450971027,Dummy -2 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
+450971027,Dummy -2 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
 703870028,Dummy -2 Laterality indicator reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
 447566020,Dummy -2 Virtual medicinal product simple reference set (foundation metadata concept),20130112,Refset Stub,en_US,simple,20130119,20130119,900000000000012004,true
-447565021,Dummy -2 Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
+447565021,Dummy -2 Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
 700043033,Dummy -3 Example problem list concepts reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
 450973035,Dummy -3 GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-450971037,Dummy -3 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-703870038,Dummy -3 Laterality indicator reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
+450971037,Dummy -3 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+703870038,Dummy -3 Laterality indicator reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
 447566030,Dummy -3 Virtual medicinal product simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-447565031,Dummy -3 Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-700043043,Dummy -4 Example problem list concepts reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-450973045,Dummy -4 GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-450971047,Dummy -4 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-703870048,Dummy -4 Laterality indicator reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-447566040,Dummy -4 Virtual medicinal product simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-447565041,Dummy -4 Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-700043053,Dummy -5 Example problem list concepts reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-450973055,Dummy -5 GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-450971057,Dummy -5 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
+447565031,Dummy -3 Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+700043043,Dummy -4 Example problem list concepts reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+450973045,Dummy -4 GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+450971047,Dummy -4 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+703870048,Dummy -4 Laterality indicator reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+447566040,Dummy -4 Virtual medicinal product simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+447565041,Dummy -4 Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+700043053,Dummy -5 Example problem list concepts reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+450973055,Dummy -5 GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+450971057,Dummy -5 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
 703870058,Dummy -5 Laterality indicator reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-447566050,Dummy -5 Virtual medicinal product simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-447565051,Dummy -5 Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
+447566050,Dummy -5 Virtual medicinal product simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+447565051,Dummy -5 Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
 700043063,Dummy -6 Example problem list concepts reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-450973065,Dummy -6 GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-450971067,Dummy -6 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-703870068,Dummy -6 Laterality indicator reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-447566060,Dummy -6 Virtual medicinal product simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-447565061,Dummy -6 Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
+450973065,Dummy -6 GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+450971067,Dummy -6 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+703870068,Dummy -6 Laterality indicator reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+447566060,Dummy -6 Virtual medicinal product simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+447565061,Dummy -6 Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
 700043073,Dummy -7 Example problem list concepts reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-450973075,Dummy -7 GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-450971077,Dummy -7 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-703870078,Dummy -7 Laterality indicator reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
+450973075,Dummy -7 GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+450971077,Dummy -7 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+703870078,Dummy -7 Laterality indicator reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
 447566070,Dummy -7 Virtual medicinal product simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-447565071,Dummy -7 Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-700043083,Dummy -8 Example problem list concepts reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-450973085,Dummy -8 GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-450971087,Dummy -8 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-703870088,Dummy -8 Laterality indicator reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-447566080,Dummy -8 Virtual medicinal product simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-447565081,Dummy -8 Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-700043093,Dummy -9 Example problem list concepts reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-450973095,Dummy -9 GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-450971097,Dummy -9 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-703870098,Dummy -9 Laterality indicator reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-447566090,Dummy -9 Virtual medicinal product simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
-447565091,Dummy -9 Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,true
+447565071,Dummy -7 Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+700043083,Dummy -8 Example problem list concepts reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+450973085,Dummy -8 GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+450971087,Dummy -8 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+703870088,Dummy -8 Laterality indicator reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+447566080,Dummy -8 Virtual medicinal product simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+447565081,Dummy -8 Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+700043093,Dummy -9 Example problem list concepts reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+450973095,Dummy -9 GP/FP health issue reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+450971097,Dummy -9 GP/FP reason for encounter reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+703870098,Dummy -9 Laterality indicator reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+447566090,Dummy -9 Virtual medicinal product simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false
+447565091,Dummy -9 Virtual therapeutic moiety simple reference set (foundation metadata concept),20120112,Refset Stub,en_US,simple,20120119,20130119,900000000000012004,false

--- a/refset-query-interface/src/main/webapp/WEB-INF/spring/appServlet/common-app-config.xml
+++ b/refset-query-interface/src/main/webapp/WEB-INF/spring/appServlet/common-app-config.xml
@@ -45,6 +45,27 @@
 		</bean>	
 		
 		<bean id="documentationConfig" class="com.mangofactory.swagger.configuration.DocumentationConfig"/>	
+		
+		
+		<bean id="conversionService" class="org.springframework.format.support.FormattingConversionServiceFactoryBean">
+	        <property name="registerDefaultFormatters" value="false" />
+	        <property name="formatters">
+	        <set>
+	            <bean class="org.springframework.format.number.NumberFormatAnnotationFormatterFactory" />
+	        </set>
+	        </property>
+	        <property name="formatterRegistrars">
+	        <set>
+	          <bean class="org.springframework.format.datetime.joda.JodaTimeFormatterRegistrar">
+	              <property name="dateFormatter">
+	                  <bean class="org.springframework.format.datetime.joda.DateTimeFormatterFactoryBean">
+	                      <property name="pattern" value="yyyyMMdd"/>
+	                  </bean>
+	              </property>
+	          </bean>
+	      </set>
+	      </property>
+	    </bean>			
 
 
 </beans>

--- a/refset-query-interface/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
+++ b/refset-query-interface/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
@@ -4,6 +4,7 @@
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"
+	xmlns:p="http://www.springframework.org/schema/p"
 	xsi:schemaLocation="http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
@@ -12,21 +13,48 @@
 	<!-- DispatcherServlet Context: defines this servlet's request-processing infrastructure -->
 	
 	<!-- Enables the Spring MVC @Controller programming model -->
-	<annotation-driven>
+	<annotation-driven conversion-service="conversionService">
 		<message-converters register-defaults="true">
-	        <beans:bean class="org.springframework.http.converter.json.MappingJackson2HttpMessageConverter">
-	            <beans:property name="objectMapper">
-	                <beans:bean class="com.fasterxml.jackson.databind.ObjectMapper">
-	                    <beans:property name="serializationInclusion">
-	                        <beans:value type="com.fasterxml.jackson.annotation.JsonInclude.Include">NON_EMPTY</beans:value>
-	                    </beans:property>
-	                </beans:bean>
-	            </beans:property>
+	        <beans:bean class="org.springframework.http.converter.json.MappingJackson2HttpMessageConverter" >
+	           
+	            <beans:property name="objectMapper" ref="objectMapper" />
+
 	        </beans:bean>
 	    </message-converters>		
 	</annotation-driven>
 	<default-servlet-handler/>
+	
+	<beans:bean id="objectMapper"
+	    class="org.springframework.http.converter.json.Jackson2ObjectMapperFactoryBean"
+	    p:indentOutput="true" p:simpleDateFormat="yyyy-MM-dd'T'HH:mm:ss.SSSZ" 
+	    p:serializationInclusion-ref="NOT_EMPTY">
+	</beans:bean>
+	<beans:bean
+	    class="org.springframework.beans.factory.config.MethodInvokingFactoryBean"
+	    p:targetObject-ref="objectMapper" p:targetMethod="registerModule">
+	    <beans:property name="arguments">
+	        <beans:list>
+	            <beans:bean class="com.fasterxml.jackson.datatype.joda.JodaModule" />
+	        </beans:list>
+	    </beans:property>
+	</beans:bean>
+	
 
+	<util:constant static-field="com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY" id="NOT_EMPTY"/>
+	<util:constant static-field="org.springframework.format.annotation.DateTimeFormat.ISO.DATE_TIME" id="ISO.DATE_TIME"/>
+	
+	
+
+
+	<beans:bean
+	    class="org.springframework.beans.factory.config.MethodInvokingFactoryBean"
+	    p:targetObject-ref="objectMapper" p:targetMethod="registerModule">
+	    <beans:property name="arguments">
+	        <beans:list>
+	            <beans:bean class="com.fasterxml.jackson.datatype.joda.JodaModule" />
+	        </beans:list>
+	    </beans:property>
+	</beans:bean>
 	<!-- Handles HTTP GET requests for /resources/** by efficiently serving up static resources in the ${webappRoot}/resources directory -->
 	<resources mapping="/resources/**" location="/resources/" />
 	<resources mapping="/webjars/**" location="classpath:/META-INF/resources/webjars/"/>

--- a/refset-query-interface/src/test/java/org/ihtsdo/otf/refset/controller/RefsetBrowseControllerTest.java
+++ b/refset-query-interface/src/test/java/org/ihtsdo/otf/refset/controller/RefsetBrowseControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
@@ -76,7 +77,7 @@ public class RefsetBrowseControllerTest {
 		when(refset.getDescription()).thenReturn("Junit Refset"); 
 		when(refset.getModuleId()).thenReturn("Junit_module_1");
 		when(refset.getMembers()).thenReturn(null);
-		when(refset.getCreated()).thenReturn(new Date().toString());
+		when(refset.getCreated()).thenReturn(Calendar.getInstance().getTime().toString());
 		when(refset.getCreatedBy()).thenReturn("Junit author");
 		when(refset.getType()).thenReturn(RefsetType.simple);
 	}

--- a/refset-query-interface/src/test/java/org/ihtsdo/otf/refset/domain/RefsetJsonConversionTest.java
+++ b/refset-query-interface/src/test/java/org/ihtsdo/otf/refset/domain/RefsetJsonConversionTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -76,7 +77,7 @@ public class RefsetJsonConversionTest {
 		Refset r = new Refset();
 		
 		r.setId("700043003");
-		r.setCreated(new Date().toString());
+		r.setCreated("20130119");
 		r.setCreatedBy("Junit Refset Editor");
 		r.setDescription("GP/FP health issue reference set (foundation metadata concept)");
 		
@@ -132,7 +133,7 @@ public class RefsetJsonConversionTest {
 		r.setLanguageCode("en-GB");
 		
 		r.setPublished(true);
-		r.setPublishedDate(new Date().toString());
+		r.setPublishedDate("20130119");
 		
 		r.setTypeId("5000");
 		r.setSuperRefsetTypeId("none");

--- a/refset-query-interface/src/test/java/org/ihtsdo/otf/refset/domain/ResponseTest.java
+++ b/refset-query-interface/src/test/java/org/ihtsdo/otf/refset/domain/ResponseTest.java
@@ -56,10 +56,10 @@ public class ResponseTest {
 		for (int i = 0; i < 11; i++) {
 			
 			Refset r = new Refset();
-			r.setCreated( new Date().toString() );
+			r.setCreated( "20130119");
 			r.setCreatedBy( "Junit Author - " + i );
 			r.setDescription( "Junit Refset" );
-			r.setEffectiveTime( new Date().toString() );
+			r.setEffectiveTime( "20130119");
 			r.setId( "2000000" + i + 10 );
 			
 			rs.add(r);

--- a/refset-query-interface/src/test/java/org/ihtsdo/otf/refset/service/RefsetBrowseServiceStubDataTest.java
+++ b/refset-query-interface/src/test/java/org/ihtsdo/otf/refset/service/RefsetBrowseServiceStubDataTest.java
@@ -36,7 +36,7 @@ public class RefsetBrowseServiceStubDataTest {
 		
 		assertNotNull(refsets);
 		assertTrue(!refsets.isEmpty());
-		assertEquals(60, refsets.size());
+		assertEquals(59, refsets.size());
 		
 		
 	}

--- a/refset-query-interface/src/test/java/org/ihtsdo/otf/refset/service/RefsetBrowseServiceStubTest.java
+++ b/refset-query-interface/src/test/java/org/ihtsdo/otf/refset/service/RefsetBrowseServiceStubTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +50,7 @@ public class RefsetBrowseServiceStubTest {
 		when(refset.getDescription()).thenReturn("Junit Refset"); 
 		when(refset.getModuleId()).thenReturn("Junit_module_1");
 		when(refset.getMembers()).thenReturn(null);
-		when(refset.getCreated()).thenReturn(new Date().toString());
+		when(refset.getCreated()).thenReturn(Calendar.getInstance().getTime().toString());
 		when(refset.getCreatedBy()).thenReturn("Junit author");
 		when(refset.getType()).thenReturn(RefsetType.simple);
 


### PR DESCRIPTION
Fixed date format to ISO. There is big gotcha in java.util.Date and it does not inter operate easily with real ISO format hence JODA is used. However JODA too work annoyingly if you input it a util date partly because util date does not have time zone. At the moment is application assumed that date has format yyyyMMdd as string and then convert in ISO using JODA lib.

Also updated data to satisfy various front end requirements 
